### PR TITLE
Allow caching the wsdl

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,19 @@ An Elixir client for SOAP Services using the erlang detergent library.
 3) Call web services using `Detergentex.call(wsdl, method, parameters)`:
 
 ```elixir
-Detergentex.call("http://www.webservicex.net/convertVolume.asmx?WSDL","ChangeVolumeUnit", ["100","dry","centiliter"])
+wsdl_url = "http://www.webservicex.net/convertVolume.asmx?WSDL"
+action = "ChangeVolumeUnit"
+parameters = ["100","dry","centiliter"]
+
+Detergentex.call(wsdl_url, action, parameters)
+
+# Cache the wsdl to do recurrent calls quickly
+
+wsdl = Detergentex.init_model(wsdl_url)
+
+Detergentex.call(wsdl, action, parameters)
+Detergentex.call(wsdl, action, parameters)
+Detergentex.call(wsdl, action, parameters)
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ parameters = ["100","dry","centiliter"]
 Detergentex.call(wsdl_url, action, parameters)
 
 # Cache the wsdl to do recurrent calls quickly
-
 wsdl = Detergentex.init_model(wsdl_url)
 
 Detergentex.call(wsdl, action, parameters)

--- a/lib/detergentex.ex
+++ b/lib/detergentex.ex
@@ -10,7 +10,15 @@ defmodule Detergentex do
       Supervisor.start_link(children, opts)
   end
 
-  def call(wsdl_url, method, params) do
-    Detergentex.Client.call_service(wsdl_url, method, params)
+  def call(wsdl, method, params) do
+    Detergentex.Client.call_service(wsdl, method, params)
+  end
+
+  def init_model(wsdl_url, prefix \\ 'p') do
+    Detergentex.Client.init_model(wsdl_url, prefix)
+  end
+
+  def is_wsdl(wsdl) do
+    Detergentex.Client.is_wsdl(wsdl)
   end
 end

--- a/lib/detergentex/client.ex
+++ b/lib/detergentex/client.ex
@@ -6,8 +6,17 @@ defmodule Detergentex.Client do
     GenServer.start_link(__MODULE__, {}, [name: :detergent_client])
   end
 
-  def call_service(wsdl_url, method, params) do
+  def call_service(wsdl, method, params) do
+    if not is_wsdl(wsdl) do
+      wsdl = to_char_list wsdl
+    end
     detergent_params = Enum.map(params, fn(elem) -> to_char_list(elem) end)
-    :detergent.call(to_char_list(wsdl_url), to_char_list(method), detergent_params)
-  end  
+    :detergent.call(wsdl, to_char_list(method), detergent_params)
+  end
+
+  def init_model(wsdl_url, prefix \\ 'p') do
+    :detergent.initModel(to_char_list(wsdl_url), to_char_list(prefix))
+  end
+
+  def is_wsdl(wsdl), do: :detergent.is_wsdl(wsdl)
 end

--- a/test/detergentex_test.exs
+++ b/test/detergentex_test.exs
@@ -1,8 +1,21 @@
 defmodule DetergentexTest do
   use ExUnit.Case
 
+  @wsdl_url "http://www.webservicex.net/convertVolume.asmx?WSDL"
+  @action "ChangeVolumeUnit"
+  @parameters ["100","dry","centiliter"]
+
   test "should make a call to a web service" do
-    {:ok, _, response} = Detergentex.call("http://www.webservicex.net/convertVolume.asmx?WSDL","ChangeVolumeUnit", ["100","dry","centiliter"])
+    {:ok, _, response} = Detergentex.call(@wsdl_url, @action, @parameters)
+    assert Enum.count(response) == 1
+  end
+
+  test "should create a wsdl model and accept it to do calls" do
+    wsdl = Detergentex.init_model @wsdl_url
+    
+    assert Detergentex.is_wsdl wsdl
+
+    {:ok, _, response} = Detergentex.call(wsdl, @action, @parameters)
     assert Enum.count(response) == 1
   end
 end


### PR DESCRIPTION
With detergent it is possible to generate a model of the `wsdl` and reuse it for recurrent calls, this avoids downloading the `wsdl` multiple times and therefore allows quicker requests.
