### PR TITLE
client: Fix lint error in variable assignment

### DIFF
--- a/lib/detergentex/client.ex
+++ b/lib/detergentex/client.ex
@@ -7,8 +7,8 @@ defmodule Detergentex.Client do
   end
 
   def call_service(wsdl, method, params) do
-    if not is_wsdl(wsdl) do
-      wsdl = to_char_list wsdl
+    wsdl = if not is_wsdl(wsdl) do
+      to_charlist(wsdl)
     end
     method_to_call = to_char_list(method)
     detergent_params = convert_to_detergent_params(params)


### PR DESCRIPTION
This commit fixes a lint error where the variable `wsdl` is assigned in
a `if` statement. When compiled, this brings up a lint warning.

This change was necessary as the variable was assigned during a `if`
statement, which meant that it was possible the variable would be kept
inside the if statement scope, instead of in the function itself.

This commit **fixes** that error, and assigns the variable if the
conditional is matched. If not, it's ignored.

Signed-off-by: Dom Rodriguez <shymega@shymega.org.uk>
Acked-by: Dom Rodriguez <shymega@shymega.org.uk>