### PR TITLE
Fix mix lint error

### DIFF
--- a/lib/detergentex/client.ex
+++ b/lib/detergentex/client.ex
@@ -7,8 +7,8 @@ defmodule Detergentex.Client do
   end
 
   def call_service(wsdl, method, params) do
-    if not is_wsdl(wsdl) do
-      wsdl = to_char_list wsdl
+    wsdl = if not is_wsdl(wsdl) do
+      to_charlist(wsdl)
     end
     method_to_call = to_char_list(method)
     detergent_params = convert_to_detergent_params(params)

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Detergentex.Mixfile do
     [app: :detergentex,
      version: "0.0.7",
      elixir: "~> 1.0",
-     deps: deps,
+     deps: deps(),
      package: [
       contributors: ["Ricardo Echavarria", "Jonas Trevisan", "David Escobar"],
       licenses: ["MIT"],


### PR DESCRIPTION
This fixes a mix lint error, where `deps` is called and made to sound like a variable, but Elixir wants it to be an **explicit** function call.

Also, not sure if this PR will work. I had some trouble with merging the latest commits. Let me know if it doesn't :smile: